### PR TITLE
Add test and example of left-pad a List[Int]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Example usage to left-pad a `String` with spaces:
 ```scala
 scala> import left.cats._
 
-scala> LeftPad[String,Char].leftPad("asdf")(10, '-')
+scala> LeftPad[String, Char].leftPad("asdf")(10, '-')
 res0: String = ------asdf
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,23 +9,43 @@ A scala implementation of the [left-pad javascript library](https://www.npmjs.co
 
 I was inspired by [this article](http://arstechnica.com/information-technology/2016/03/rage-quit-coder-unpublished-17-lines-of-javascript-and-broke-the-internet/) to port this to Scala.
 
-This implementation will let you pad arbitrary F[A] structures with As
-as long as you have implicit cats.Foldable and cats.Alternative instances.
+Example usage to left-pad a `String` with spaces:
 
-example usage:
+```scala
+scala> import left.cats._
 
-    scala> import left.cats._
-    import left.cats._
-
-    scala> LeftPad[String,Char].leftPad("asdf")(10, '-')
-    res0: String = ------asdf
+scala> LeftPad[String,Char].leftPad("asdf")(10, '-')
+res0: String = ------asdf
+```
 
 with syntax:
 
-    scala> import LeftPad.ops._
-    import LeftPad.ops._
+```scala
+scala> import LeftPad.ops._
 
-    scala> "asdf".leftPad(10, '-')
-    res1: String = ------asdf
+scala> "asdf".leftPad(10, '-')
+res1: String = ------asdf
+```
+
+Additionally, this implementation will let you pad arbitrary `F[A]` structures with `A`s
+as long as you have implicit `cats.Foldable` and `cats.Alternative` instances.
+
+Example usage to left-pad a `List[Int]` with `0`'s:
+
+```scala
+scala> import cats._, cats.implicits._, left.cats._, LeftPad._
+
+scala> LeftPad[List[Int], Int].leftPad(List(1, 2, 3, 4))(8, 0) 
+res2: List[Int] = List(0, 0, 0, 0, 1, 2, 3, 4)
+```
+
+with syntax:
+
+```scala
+scala> import cats._, cats.implicits._, left.cats._, LeftPad._, LeftPad.ops._
+
+scala> List(1, 2, 3, 4).leftPad(8, 0)
+res3: List[Int] = List(0, 0, 0, 0, 1, 2, 3, 4)
+```
 
 Of course, it builds in scalaJS as well.

--- a/core/src/test/scala/LeftPadSpec.scala
+++ b/core/src/test/scala/LeftPadSpec.scala
@@ -19,6 +19,10 @@ object LeftPadSpec extends Properties("left-pad") {
     LeftPad[Vector[Char],Char].leftPad(a)(n,c).foldMap(_.toString) == LeftPad[String,Char].leftPad(a.mkString(""))(n,c)
   }
 
+  property("alternative foldable: List[Int]") = forAll { (a: List[Int], i: Int, n: Int) =>
+    LeftPad[List[Int], Int].leftPad(a)(n, i) == (if (n <= a.length) a else Stream.continually(i).take(n - a.length).toList ++ a)
+  }
+
   property("zero") = forAll { (w: Char, s: String) =>
     LeftPad[String, Char].leftPad(s)(s.length, w) == s
   }


### PR DESCRIPTION
Goal: taking this project seriously as a way to quickly leverage the world-wide uproar over npm's left-pad in order to demonstrate a small and approachable example of generalizing the (universally understood) concept of left-pad to an operation over arbitrary types in a painless way.
